### PR TITLE
Fix for more complex dasherize jobs

### DIFF
--- a/src/to-hyperscript/converter.ts
+++ b/src/to-hyperscript/converter.ts
@@ -7,37 +7,32 @@ export interface Converter {
 }
 
 export function createConverter(options:Options) : Converter {
-  
+
   var prefix = (options.prefix || "h");
   const regex = createRegExp(options);
-  
-  const camelCase = new RegExp("([a-z])([A-Z])", "g");
-  
-  let convertToDash = (match:string, before:string, after:string) => {
-    return before+"-"+after.toLowerCase();
-  }
-  
+
   let dasherize = (s: string) => {
     if (options.dasherize === false) {
       return s;
     }
-    return s.replace(camelCase, convertToDash);
+
+    return s.replace(/([A-Z])/g, '-$1').toLowerCase();
   }
-  
+
   let convertMatch = (match:string, group1: string) => {
     var addComma = match[match.length-1] !== ")";
     return prefix + "(\"" + dasherize(group1.substr(1)) + "\"" + (addComma ? ", " : ")");
   }
-  
+
   let convertLine = (line: string) => {
     return line.replace(regex, convertMatch);
   }
-  
+
   let convert = (script:string) => {
     return script.split("\n").map(convertLine).join("\n");
   }
-  
+
   return {convert, convertLine};
 };
-  
+
 //export {CompactDomToHyperscript};

--- a/test/to-hyperscript/converter-tests.ts
+++ b/test/to-hyperscript/converter-tests.ts
@@ -15,29 +15,29 @@ describe("convertLine", () => {
     const line = 'h("div", [h("input", {type: "text", placeholder: "name?", value: you}),h("p.output", ["Hello " + (you || "you") + "!"])]);';
     expect(converter.convertLine(line)).to.equal(line);
   });
-  
+
   it("should replace the simpelest case", () => {
     const line = 'h.div()';
     expect(converter.convertLine(line)).to.equal('h("div")');
     const line2 = 'h.div( )';
     expect(converter.convertLine(line2)).to.equal('h("div")');
   });
-  
+
   it("should replace a tag with classnames and content", () => {
     const line = 'h.a.button.primary({href:"#"}, ["Click me"])';
     expect(converter.convertLine(line)).to.equal('h("a.button.primary", {href:"#"}, ["Click me"])');
   });
-  
+
   it("should dasherize tagnames and classnames", () => {
-    const line = 'h.myButton.extraPriority("Click me")';
-    expect(converter.convertLine(line)).to.equal('h("my-button.extra-priority", "Click me")');
+    const line = 'h.myButton.extraXPriority("Click me")';
+    expect(converter.convertLine(line)).to.equal('h("my-button.extra-x-priority", "Click me")');
   });
-  
+
   it("should work with multiple tags on one line", () => {
     const line = 'h.div(h.p([h.a("click me")]))';
     expect(converter.convertLine(line)).to.equal('h("div", h("p", [h("a", "click me")]))');
   });
-  
+
   it("should convert a script with multiple lines", () => {
     const script = `
 function renderMaquette() {
@@ -48,12 +48,12 @@ function renderMaquette() {
 }`;
     const expected = `
 function renderMaquette() {
-  return h("div", 
+  return h("div",${" "}
     h("input", {type: "text", value: you, oninput: handleNameInput}),
     h("p.output", "Hello " + you)
   );
 }`;
     expect(converter.convert(script)).to.equal(expected);
   });
-  
+
 });


### PR DESCRIPTION
We now support cases like this: `extraXPriority` > `extra-x-priority` .
(Atom also stripped some trailing white-space of which one case was
within a string literal which we brute-forced back in)
